### PR TITLE
Add an Update method to DepthCharge to move the charges downward and …

### DIFF
--- a/Assets/Scenes/SubBoom.cs
+++ b/Assets/Scenes/SubBoom.cs
@@ -169,13 +169,32 @@ public class SubBoom : MonoBehaviour
             submarines.Add(new Submarine());
         }
 
+        // Update depth charges, keep track of exploded charges
+        List<DepthCharge> explodedCharges = new List<DepthCharge>();
+        foreach (var dc in depthCharges) {
+            dc.Update(Time.deltaTime);
+            if (dc.secondsSinceDropped >= dc.timeUntilExplode) {
+                explodedCharges.Add(dc);
+            }
+        }
+
+        // Clear exploded depth charges
+        // TODO: create an explosion object in its place
+        foreach (var dc in explodedCharges) {
+            Destroy(dc.depthCharge);
+            depthCharges.Remove(dc);
+        }
+
         scoreText.text = "Score: " + score.ToString();
     }
 }
 
 public class DepthCharge
 {
-    GameObject depthCharge;
+    public GameObject depthCharge;
+    float velocity = -0.5f;
+    public float secondsSinceDropped = 0.0f;
+    public float timeUntilExplode = 10.0f;
 
     public DepthCharge(Vector2 destroyerPosition)
     {
@@ -199,5 +218,12 @@ public class DepthCharge
         //if a charge's collision makes contact with a submarine's collision
         //create explosion effect, deactivate/delete charge, and deactivate/delete submarine
         Debug.Log("Charge Exploded!");
+    }
+
+    public void Update(float dt) {
+        secondsSinceDropped += dt;
+        Vector2 pos = depthCharge.transform.position;
+        pos.y += dt * velocity;
+        depthCharge.transform.position = pos;
     }
 }


### PR DESCRIPTION
…track how long they've existed.

Added a few lines of code to the SubBoom Update method that move the depth charges downward, update a time counter on how long they've existed and remove any depth charges that have reached 10 seconds or more of life time. Let me know what you think, if it makes sense and looks good to you I can merge this feature branch "update_depth_charges" into main and we can keep hacking.

I wanted to add you as a "reviewer" on this pull request but for some reason you're not showing up as an option at the moment @spicewooddev ... maybe once you accept your collaborator status? We'll figure that out eventually.