### PR TITLE
Try adding rigidbody2d

### DIFF
--- a/Assets/Scenes/SubBoom.cs
+++ b/Assets/Scenes/SubBoom.cs
@@ -15,7 +15,8 @@ static class Utilities {
         Sprite sprite = Sprite.Create(tex, new UnityEngine.Rect(0.0f,0.0f,tex.width,tex.height), new Vector2(0.5f, 0.5f), (float) tex.width);
         renderer.sprite = sprite;
         renderer.color = color;
-        BoxCollider2D collider = go.AddComponent<BoxCollider2D>();
+        go.AddComponent<Rigidbody2D>();
+        go.AddComponent<BoxCollider2D>();
 
         return go;
     }

--- a/Assets/Scenes/SubBoom.cs
+++ b/Assets/Scenes/SubBoom.cs
@@ -15,8 +15,10 @@ static class Utilities {
         Sprite sprite = Sprite.Create(tex, new UnityEngine.Rect(0.0f,0.0f,tex.width,tex.height), new Vector2(0.5f, 0.5f), (float) tex.width);
         renderer.sprite = sprite;
         renderer.color = color;
-        go.AddComponent<Rigidbody2D>();
-        go.AddComponent<BoxCollider2D>();
+        Rigidbody2D body = go.AddComponent<Rigidbody2D>();
+        body.gravityScale = 0f;
+        BoxCollider2D collider = go.AddComponent<BoxCollider2D>();
+        collider.isTrigger = true;
 
         return go;
     }
@@ -278,31 +280,12 @@ public class ExplosionEffect
 
     public ExplosionEffect(Vector2 explosionPosition)
     {
-        Texture2D textureOutline = Resources.Load<Texture2D>("outline_square");
-        Texture2D textureExplosion = Resources.Load<Texture2D>("blank_circle");
-        Sprite spriteOutline;
-        Sprite spriteCircle;
-        SpriteRenderer renderer;
-
-        explodeCharge = new GameObject("Explosion");
-        explodeCharge.transform.localScale = new Vector3(0.5f, 0.5f, 1);
-        explodeCharge.transform.position = explosionPosition;
-
-        renderer = explodeCharge.AddComponent<SpriteRenderer>();
-        //renderer.color = new Color(0.2f, 0.3f, 0.4f, 0.0f);
-        spriteOutline = Sprite.Create(textureOutline,
-            new UnityEngine.Rect(0.0f, 0.0f, textureOutline.width, textureOutline.height),
-            new Vector2(0.5f, 0.5f), (float)textureOutline.width);
-        renderer.sprite = spriteOutline;
-
-        BoxCollider2D collider = explodeCharge.AddComponent<BoxCollider2D>();
-
-        /*
-        spriteCircle = Sprite.Create(textureExplosion,
-            new UnityEngine.Rect(0.0f, 0.0f, textureExplosion.width, textureExplosion.height),
-            new Vector2(0.5f, 0.5f), (float)textureExplosion.width);
-        renderer.sprite = spriteCircle;
-        */
+        explodeCharge = Utilities.newSpriteGameObject(
+            "Explosion",
+            new Vector3(0.5f, 0.5f, 1),
+            explosionPosition,
+            new Color(1.0f, 0.5f, 0.0f, 1.0f)
+        );
     }
 
     //maybe add another variable to the method that will grab the current explodeCharge's collider component?

--- a/Assets/Scenes/SubBoom.cs
+++ b/Assets/Scenes/SubBoom.cs
@@ -67,15 +67,6 @@ public class Submarine {
 
         submarine.transform.position = pos;
     }
-
-    //this isn't working
-    private void OnCollisionEnter(BoxCollider2D collision)
-    {
-        if (collision.gameObject.name == "Explosion")
-        {
-            Debug.Log("Submarine Down!");
-        }
-    }
 }
 
 public class SubBoom : MonoBehaviour
@@ -229,15 +220,6 @@ public class SubBoom : MonoBehaviour
 
         scoreText.text = "Score: " + score.ToString();
     }
-
-    //this isn't meant to work anyways. but how am i getting a warning for incorrect signature??
-    private void OnCollisionEnter2D(Collision2D collision)
-    {
-        if (collision.gameObject.name == "Explosion")
-        {
-            Debug.Log("Game Over!");
-        }
-    }
 }
 
 public class DepthCharge
@@ -293,17 +275,5 @@ public class ExplosionEffect
     {
         secondsSinceDropped += explosionDuration;
         explodeCharge.transform.localScale += new Vector3 (explosionDuration, explosionDuration, 0);
-        //not sure how to increase explodeCharge collider with the way it is now
-        //update: okay so apparently the collider transforms with the local scale but idk why the collider isn't working then??
     }
-
-    /*
-    public void OnCollisionEnter(Collision collision)
-    {
-        if (collision.gameObject.name == "Submarine")
-        {
-
-        }
-    }
-    */
 }


### PR DESCRIPTION
I took a look at the code you sent as a zip file and committed it to a branch called `nikki_colliders`. This branch, `try_adding_rigidbody2d`, looks like it has more changes than it really does because Windows adds some strange new line characters that Linux is removing. The only bit that I think you should adopt in the `newSpriteGameObject` function is:

```
        Rigidbody2D body = go.AddComponent<Rigidbody2D>();
        body.gravityScale = 0f;
        BoxCollider2D collider = go.AddComponent<BoxCollider2D>();
        collider.isTrigger = true;
```

From a little bit of digging I found out that you have to have a Rigidbody2D component in order for Unity's physics system to pay attention to the game object and do collision things. This introduces some other headaches, however, like all the game objects falling down because they now obey gravity (so I turned that off with `body.gravityScale = 0f` ) and submarines pushing the ocean background around ( https://youtu.be/UJqmX6vxRDE ). To get around that you can tell Unity not do do that by making the collider a Trigger.

Once I made those changes I believe your double for loop that checks if the colliders of the explosion "IsTouching" the submarine works :) (you'll actually see an error about modifying the list you're iterating over but we can fix that another time).