### PR TITLE
Modify the submarines List outside of the foreach over the same List.

### DIFF
--- a/Assets/Scenes/SubBoom.cs
+++ b/Assets/Scenes/SubBoom.cs
@@ -362,25 +362,24 @@ public class SubBoom : MonoBehaviour
 
         //loop that checks if any items in explosions list is touching a submarine collider or destroyer collider
         //if so, destroy submarine and/or if destroyer, game over
-
-        //update: it may be easier to try the method OnCollisionEnter2D
-        //if we are able to get both box colliders somehow
+        HashSet<Submarine> deadSubmarines = new HashSet<Submarine>();
         foreach (var ec in explosions)
         {
             foreach (var sub in submarines)
             {
-                //this isn't working for some reason? not even the debug message is showing up.
                 if (ec.explodeCharge.GetComponent<BoxCollider2D>().IsTouching
-                   (sub.submarine.GetComponent<BoxCollider2D>()) == true)
+                   (sub.submarine.GetComponent<BoxCollider2D>()))
                 {
-                    Debug.Log("This works!");
-
-                    Destroy(sub.submarine);
-                    submarines.Remove(sub);
-
-                    score += 1;
+                    deadSubmarines.Add(sub);
                 }
             }
+        }
+
+        foreach (var sub in deadSubmarines)
+        {
+            Destroy(sub.submarine);
+            submarines.Remove(sub);
+            score += 1;
         }
 
         // Bubbles


### PR DESCRIPTION
Trying to add/remove items from a List while simultaneously iterating over the List in a foreach loop can lead to weird behavior and also those warnings issue #16 is reporting. The way I usually get around this is to make a second List (or HashSet in this case, to avoid the scenario where a submarine is touched by two or more explosions and we'd try to delete it multiple times) that gathers the objects that need to be removed in the first pass and then uses that collection to remove the items in a second pass.