### PR TITLE
Correct Random.Range for explosion noises, modify explosion list outs…

### DIFF
--- a/Assets/Scenes/SubBoom.cs
+++ b/Assets/Scenes/SubBoom.cs
@@ -349,15 +349,20 @@ public class SubBoom : MonoBehaviour
 
         // Create a foreach loop for the explosions list
         // That increases the scale of the explosion effect for a specified duration
+        List<ExplosionEffect> deadExplosions = new List<ExplosionEffect>();
         foreach (var ec in explosions)
         {
+            ec.UpdateMovement(Time.deltaTime);
             if (ec.secondsSinceDropped >= ec.timeUntilExplode)
             {
-                Destroy(ec.explodeCharge);
-                explosions.Remove(ec);
-                break;
+                deadExplosions.Add(ec);
             }
-            ec.UpdateMovement(Time.deltaTime);
+        }
+
+        foreach (var ec in deadExplosions)
+        {
+            Destroy(ec.explodeCharge);
+            explosions.Remove(ec);
         }
 
         //loop that checks if any items in explosions list is touching a submarine collider or destroyer collider
@@ -472,7 +477,7 @@ public class ExplosionEffect
         };
 
         AudioSource audio = explodeCharge.GetComponent<AudioSource>();
-        AudioClip sound = Resources.Load<AudioClip>(explosionSounds[UnityEngine.Random.Range(0, 6)]);
+        AudioClip sound = Resources.Load<AudioClip>(explosionSounds[UnityEngine.Random.Range(0, 5)]);
         audio.PlayOneShot(sound);
     }
 


### PR DESCRIPTION
…ide of initial foreach loop.

The `Random.Range(0,6)` would occasionally return the number `5` which is one too many for the array of explosion sound effects which would lead to the Index Out Of Bounds error seen in #22 and the "zombie explosions" that wouldn't clear.

I also updated the explosion foreach loop to remove dead explosions in a second pass to avoid errors about modifying the list during its enumeration. 