### PR TITLE
SaveGameStats once when game is over or once if window is closed by p…

### DIFF
--- a/Assets/Scenes/SubBoom.cs
+++ b/Assets/Scenes/SubBoom.cs
@@ -290,24 +290,6 @@ public class SubBoom : MonoBehaviour
                 pos.x = Mathf.Min(pos.x, 9.25f);
                 destroyer.transform.position = pos;
             }
-
-            if (Input.GetKey("escape"))
-            {
-                GameData gd = GameDataFileHandler.Load();
-                DateTime now = DateTime.Now;
-                gd.totalGamesPlayed += 1;
-                gd.totalSecondsPlayed += (ulong)timePlayed;
-                gd.lastScore = (ulong)score;
-                gd.lastScoreDateTime = now.ToString();
-                if (score >= gd.highScore)
-                {
-                    gd.highScore = score;
-                    gd.highScoreDateTime = now.ToString();
-                }
-                GameDataFileHandler.Save(gd);
-
-                SceneManager.LoadScene("MainMenuScene", LoadSceneMode.Single);
-            }
         }
 
         // Update torpedos
@@ -422,10 +404,11 @@ public class SubBoom : MonoBehaviour
 
         //instead of destroying the player object, we can deactivate it instead
         //that way, the game can be optimized a little bit
-        if (destroyer.activeInHierarchy == false)
+        if (destroyer.activeInHierarchy == false && isGameActive)
         {
             isGameActive = false;
             gameOverScreen.SetActive(true);
+            SaveGameStats();
         }
 
             // Bubbles
@@ -462,6 +445,30 @@ public class SubBoom : MonoBehaviour
     public void MainMenuClick()
     {
         SceneManager.LoadScene("MainMenuScene", LoadSceneMode.Single);
+    }
+
+    void SaveGameStats()
+    {
+        GameData gd = GameDataFileHandler.Load();
+        DateTime now = DateTime.Now;
+        gd.totalGamesPlayed += 1;
+        gd.totalSecondsPlayed += (ulong)timePlayed;
+        gd.lastScore = score;
+        gd.lastScoreDateTime = now.ToString();
+        if (score >= gd.highScore)
+        {
+            gd.highScore = score;
+            gd.highScoreDateTime = now.ToString();
+        }
+        GameDataFileHandler.Save(gd);
+    }
+
+    void OnApplicationQuit()
+    {
+        if(isGameActive)
+        {
+            SaveGameStats();
+        }
     }
 }
 


### PR DESCRIPTION
…layer.

Removing the escape key press code since it was mostly for debugging. Now save stats when the game over screen is displayed. Also save stats if the user clicks the close button on the windowed game (for the windows/mac/linux build when `OnApplicationQuit` gets called).